### PR TITLE
Removed bug that showed blank notes on list and grid

### DIFF
--- a/src/client/public/js/component.js
+++ b/src/client/public/js/component.js
@@ -11,7 +11,7 @@ export default class Component {
     this._state = state;
   }
 
-  bindUI() { }
+  bindUI() {}
 
   stateChanged(state) {
     let updated = false;
@@ -28,5 +28,5 @@ export default class Component {
     }
   }
 
-  _render() { }
+  _render() {}
 }

--- a/src/client/public/js/melodyBar.js
+++ b/src/client/public/js/melodyBar.js
@@ -16,7 +16,9 @@ class MelodyBar extends Component {
   _render() {
     const lastPlaying = document.querySelector(".playing");
     if (lastPlaying) lastPlaying.classList.remove("playing");
-    const nextPlaying = document.querySelector(".note-display-" + this._state.currentItem);
+    const nextPlaying = document.querySelector(
+      ".note-display-" + this._state.currentItem,
+    );
     if (nextPlaying) nextPlaying.classList.add("playing");
   }
 }

--- a/src/server/services/melody/ToneMelodyService.ts
+++ b/src/server/services/melody/ToneMelodyService.ts
@@ -17,15 +17,6 @@ class ToneMelodyService implements MelodyService {
     const allScales = Mode.names();
     const allNotes = Scale.get(selectedKey + " " + selectedScale).notes;
 
-    if (selectedEmptyMode === EmptyMode.Low) {
-      allNotes.push(" ");
-    }
-
-    if (selectedEmptyMode === EmptyMode.High) {
-      allNotes.push(" ");
-      allNotes.push(" ");
-    }
-
     if (pattern) {
       console.log("Woah! You already have a pattern -> " + pattern);
       return {
@@ -39,6 +30,7 @@ class ToneMelodyService implements MelodyService {
     const randomNotes: string[] = this.getRandomNotes(
       selectedNumberOfNotes,
       allNotes,
+      selectedEmptyMode,
     );
 
     return {
@@ -52,7 +44,8 @@ class ToneMelodyService implements MelodyService {
   private getRandomNotes(
     numberOfNotes: number,
     withinRange: string[] = [],
-  ): any[] {
+    selectedEmptyMode: EmptyMode,
+  ): string[] {
     let result = [];
     for (let item = 0; item < numberOfNotes; item++) {
       const element =
@@ -60,7 +53,38 @@ class ToneMelodyService implements MelodyService {
       result.push(element);
     }
 
+    if (selectedEmptyMode === EmptyMode.Low) {
+      result.pop();
+      result.push(" ");
+      result = this.shuffle(result);
+    }
+
+    if (selectedEmptyMode === EmptyMode.High) {
+      result.pop();
+      result.pop();
+      result.push(" ");
+      result.push(" ");
+      result = this.shuffle(result);
+    }
+
     return result;
+  }
+
+  private shuffle(array: string[]): string[] {
+    var currentIndex = array.length,
+      temporaryValue,
+      randomIndex;
+
+    while (0 !== currentIndex) {
+      randomIndex = Math.floor(Math.random() * currentIndex);
+      currentIndex -= 1;
+
+      temporaryValue = array[currentIndex];
+      array[currentIndex] = array[randomIndex];
+      array[randomIndex] = temporaryValue;
+    }
+
+    return array;
   }
 }
 

--- a/tests/client/melodyBar.spec.js
+++ b/tests/client/melodyBar.spec.js
@@ -4,8 +4,11 @@ describe("Melody bar component", () => {
   const pattern = ["A", "B", "C"];
   document.body.innerHTML = `<div class='note-container'>
             ${pattern
-      .map((note, index) => "<div class='note-display-" + index + "'>" + note + "</div>")
-      .join("")}
+              .map(
+                (note, index) =>
+                  "<div class='note-display-" + index + "'>" + note + "</div>",
+              )
+              .join("")}
         </div>`;
 
   const mockCallback = jest.fn();
@@ -17,7 +20,9 @@ describe("Melody bar component", () => {
   it("should highlight the current playing note", () => {
     pattern.forEach((note, index) => {
       melodyBar.stateChanged({ currentItem: index });
-      const shouldBePlayingElement = document.querySelector(".playing.note-display-" + index);
+      const shouldBePlayingElement = document.querySelector(
+        ".playing.note-display-" + index,
+      );
       expect(shouldBePlayingElement).not.toBeNull();
     });
   });

--- a/tests/server/services/ToneMelodyService.spec.ts
+++ b/tests/server/services/ToneMelodyService.spec.ts
@@ -66,9 +66,22 @@ describe("ToneMelodyService", () => {
       ],
       allEmptyModes: ["None", "Low", "High"],
     };
-    expect(result.allNotes).toEqual(expectedResult.allNotes);
-    expect(result.allScales).toEqual(expectedResult.allScales);
-    expect(result.allEmptyModes).toEqual(expectedResult.allEmptyModes);
-    expect(result.pattern).toEqual(expectedResult.pattern);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("should add blank notes in pattern but not in allNotes returned", () => {
+    const settings: Settings = {
+      selectedEmptyMode: EmptyMode.High,
+      selectedKey: "C",
+      selectedNumberOfNotes: 8,
+      selectedTempo: 240,
+      selectedScale: "lydian",
+      pattern: null,
+    };
+
+    const result = service.buildRandomResult(settings);
+
+    expect(result.pattern).toContain(" ");
+    expect(result.allNotes).not.toContain(" ");
   });
 });


### PR DESCRIPTION
# Description

This set of changes includes a fix for the additional "empty notes" appearing on the list of notes and in the grid.
This required a slight rework of our randomisation code to only include the "empty notes" in the final pattern and not the list of notes used to generate that pattern.

Closes #7 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added docs according to the standard. [docs guideline](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
